### PR TITLE
Add CSV upload loader and dashboard integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,11 @@ python erpguard/reporting/generate_report.py
 streamlit run erpguard/dashboard/app.py
 ```
 
+### Upload sample data
+Use the dashboard sidebar to upload CSV files for the `items_master`,
+`suppliers` and `equipment` tables. Click **Load and Run** to populate
+the database and execute the validation rules.
+
 ### Render deployment
 ERPGuard is also ready for [Render](https://render.com) hosting. The `render.yaml`
 file provisions a free PostgreSQL 16 database named `api-db` and injects its

--- a/erpguard/dashboard/app.py
+++ b/erpguard/dashboard/app.py
@@ -1,11 +1,31 @@
+import pandas as pd
 import streamlit as st
 
 from erpguard.compliance_summary import generate_summary
-
+from erpguard.database.loader import load_dataframe
+from erpguard.validation.rules_engine import run_rules
 
 st.title("ERPGuard Dashboard")
-summary = generate_summary()
 
+st.sidebar.header("Upload CSV Data")
+items_file = st.sidebar.file_uploader("Items master", type="csv")
+suppliers_file = st.sidebar.file_uploader("Suppliers", type="csv")
+equipment_file = st.sidebar.file_uploader("Equipment", type="csv")
+
+if st.sidebar.button("Load and Run"):
+    if items_file:
+        items_df = pd.read_csv(items_file)
+        load_dataframe(items_df, "items_master")
+    if suppliers_file:
+        suppliers_df = pd.read_csv(suppliers_file)
+        load_dataframe(suppliers_df, "suppliers")
+    if equipment_file:
+        equipment_df = pd.read_csv(equipment_file)
+        load_dataframe(equipment_df, "equipment")
+    run_rules()
+    st.sidebar.success("Data loaded and rules executed")
+
+summary = generate_summary()
 for rule, data in summary.items():
     passes = data.get("PASS", 0)
     fails = data.get("FAIL", 0)

--- a/erpguard/database/loader.py
+++ b/erpguard/database/loader.py
@@ -1,0 +1,23 @@
+import pandas as pd
+from psycopg2.extras import execute_batch
+
+from .connection import get_connection
+
+
+def load_dataframe(df: pd.DataFrame, table_name: str) -> None:
+    """Replace table contents with DataFrame values."""
+    if df.empty:
+        return
+
+    columns = list(df.columns)
+    records = [tuple(row) for row in df.itertuples(index=False, name=None)]
+
+    placeholders = ", ".join(["%s"] * len(columns))
+    cols = ", ".join(columns)
+    query = f"INSERT INTO {table_name} ({cols}) VALUES ({placeholders})"
+
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(f"TRUNCATE {table_name} RESTART IDENTITY")
+            execute_batch(cur, query, records)
+        conn.commit()


### PR DESCRIPTION
## Summary
- enable data uploads via `streamlit` dashboard
- load DataFrame into tables with new `load_dataframe` helper
- document new upload workflow in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686800b4378c832ca3dc3ab35050a031