### PR TITLE
Add tabbed rule summary

### DIFF
--- a/erpguard/compliance_summary.py
+++ b/erpguard/compliance_summary.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+import pandas as pd
 
 from erpguard.database.connection import get_connection
 
@@ -14,6 +15,34 @@ def generate_summary() -> dict:
             for rule_name, status, count in cur.fetchall():
                 summary[rule_name][status] = count
         return summary
+
+
+def generate_summary_by_category() -> pd.DataFrame:
+    """Return a DataFrame summarizing rule results with derived categories."""
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(
+                """SELECT rule_name, status, COUNT(*) FROM rule_results GROUP BY rule_name, status"""
+            )
+            rows = cur.fetchall()
+
+    counts = defaultdict(lambda: {"PASS": 0, "FAIL": 0})
+    for rule_name, status, count in rows:
+        counts[rule_name][status] = count
+
+    data = []
+    for rule_name, results in counts.items():
+        category = rule_name.split("_")[0]
+        data.append(
+            {
+                "rule_name": rule_name,
+                "category": category,
+                "PASS": results.get("PASS", 0),
+                "FAIL": results.get("FAIL", 0),
+            }
+        )
+
+    return pd.DataFrame(data)
 
 
 def main() -> None:

--- a/erpguard/dashboard/app.py
+++ b/erpguard/dashboard/app.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import streamlit as st
 
-from erpguard.compliance_summary import generate_summary
+from erpguard.compliance_summary import generate_summary_by_category
 from erpguard.database.loader import load_dataframe
 from erpguard.validation.rules_engine import run_rules
 
@@ -25,8 +25,14 @@ if st.sidebar.button("Load and Run"):
     run_rules()
     st.sidebar.success("Data loaded and rules executed")
 
-summary = generate_summary()
-for rule, data in summary.items():
-    passes = data.get("PASS", 0)
-    fails = data.get("FAIL", 0)
-    st.write(f"**{rule}**: {passes} pass, {fails} fail")
+summary_df = generate_summary_by_category()
+if not summary_df.empty:
+    categories = summary_df["category"].unique()
+    tabs = st.tabs(categories)
+    for category, tab in zip(categories, tabs):
+        cat_df = summary_df[summary_df["category"] == category][[
+            "rule_name",
+            "PASS",
+            "FAIL",
+        ]]
+        tab.table(cat_df.set_index("rule_name"))


### PR DESCRIPTION
## Summary
- add helper to group rule results by category
- display results by category in dashboard

## Testing
- `python - <<'PY'
from erpguard.compliance_summary import generate_summary_by_category
PY
` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_686808cfc0fc832cbf9698b7bd4fa080