### PR TITLE
Add full-column CSV samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Use the dashboard sidebar to upload CSV files for the `items_master`,
 `suppliers` and `equipment` tables. Click **Load and Run** to populate
 the database and execute the validation rules. A set of example CSVs is
 provided in the `samples` directory for quick testing.
+For convenience `items_master_columns.csv` and `suppliers_columns.csv`
+list every column in their respective tables so the headers always match
+the database schema.
 
 ### Render deployment
 ERPGuard is also ready for [Render](https://render.com) hosting. The `render.yaml`

--- a/samples/items_master_columns.csv
+++ b/samples/items_master_columns.csv
@@ -1,0 +1,4 @@
+item_id,description,revision,lot_flag,shelf_life_days,default_supplier,change_control_ref,rework_flag,special_process
+ITEM-001,Sample item 1,A,TRUE,365,SUP-001,CC-001,FALSE,FALSE
+ITEM-002,Sample item 2,B,FALSE,,SUP-002,,TRUE,TRUE
+ITEM-003,Sample item 3,C,TRUE,180,SUP-003,CC-003,FALSE,FALSE

--- a/samples/suppliers_columns.csv
+++ b/samples/suppliers_columns.csv
@@ -1,0 +1,4 @@
+supplier_id,name,cert_expiry,approved_flag,audit_score
+SUP-001,Supplier A,2099-12-31,TRUE,95
+SUP-002,Supplier B,2000-01-01,FALSE,70
+SUP-003,Supplier C,2099-12-31,TRUE,88


### PR DESCRIPTION
## Summary
- add new sample CSV files with headers matching the database schema
- document these templates in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_686826016838832c9da7e5c3a1b62160