### PR TITLE
Add database init script

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,8 @@ MIT or proprietary — your choice.
 ```bash
 export $(cat .env | xargs)
 ```
-3. Run your compliance checks as shown in the usage section.
+3. Initialize the database schema:
+```bash
+python -m erpguard.database.init_db
+```
+4. Run your compliance checks as shown in the usage section.

--- a/erpguard/database/init_db.py
+++ b/erpguard/database/init_db.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+from erpguard.database.connection import get_connection
+
+SQL_FILE = Path(__file__).resolve().parents[2] / "docker-entrypoint-initdb.sql"
+
+
+def initialize_database() -> None:
+    """Execute the SQL schema file against the configured database."""
+    with SQL_FILE.open() as f:
+        sql = f.read()
+
+    with get_connection() as conn:
+        with conn.cursor() as cur:
+            cur.execute(sql)
+        conn.commit()
+
+
+if __name__ == "__main__":
+    initialize_database()
+    print("Database initialized")


### PR DESCRIPTION
## Summary
- document how to initialize DB schema
- add init_db script to run docker-entrypoint-initdb.sql

## Testing
- `python -m py_compile erpguard/database/init_db.py`
- `python -m erpguard.database.init_db` *(fails: ModuleNotFoundError: No module named 'psycopg2')*

------
https://chatgpt.com/codex/tasks/task_e_686827fb7374832c9dc022ddb02790fa