### PR TITLE
Remove supplier and critical categories

### DIFF
--- a/erpguard/dashboard/app.py
+++ b/erpguard/dashboard/app.py
@@ -25,7 +25,11 @@ if st.sidebar.button("Load and Run"):
     run_rules()
     st.sidebar.success("Data loaded and rules executed")
 
+EXCLUDED_CATEGORIES = {"suppliers", "critical"}
+
 summary_df = generate_summary_by_category()
+summary_df = summary_df[~summary_df["category"].isin(EXCLUDED_CATEGORIES)]
+
 if not summary_df.empty:
     categories = summary_df["category"].unique().tolist()
     tabs = st.tabs(categories)


### PR DESCRIPTION
## Summary
- filter out `suppliers` and `critical` categories from the dashboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68682e57f594832cb74a0a9d49b967c6